### PR TITLE
Bugfix in regex and changed default settings.

### DIFF
--- a/showPageAction.js
+++ b/showPageAction.js
@@ -44,10 +44,10 @@ function getBoardId(url) {
     var location = getTrelloLocation(url);
     try {
         if (location === "board") {
-            return url.match(/trello.com\/b\/[^\/]+\/([0-9a-f]+)/)[1];
+            return url.match(/trello\.com\/b\/(\w+)/)[1];
         }
         else {
-            return url.match(/trello.com\/c\/[^\/]+\/([0-9a-f]+)/)[1];
+            return url.match(/trello\.com\/c\/(\w+)/)[1];
         }
     } catch (e) {
         throw new Error("can't get board id from '" + url + "'");

--- a/showPageAction.js
+++ b/showPageAction.js
@@ -1,6 +1,6 @@
 var DEFAULT_SETTINGS = {
     maxSize: 4,
-    ghostCards: true,
+    ghostCards: false,
     labelCards: true,
     showCardNumbers: false
 }


### PR DESCRIPTION
The getBoardId function sometimes has javascript errors, the reason of this error was a wrong regex. Because of the error the personal board settings were not loaded.

Also set default of ghostCards (gray out card with no story point) to false, because most of our boards don't contain story points.
