### PR TITLE
Fixes broken plugin due to changes in markup

### DIFF
--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -257,7 +257,7 @@
     }
 
     //track card-titles
-    new TextChangeListener("a", "a.js-card-name", function (elm) {
+    new TextChangeListener("span", "span.js-card-name", function (elm) {
         var title = elm.innerText.trim(),
             $card = $(elm).closest(".list-card");
 


### PR DESCRIPTION
An `a` changed to a `span`. Things broke.

This fixes it.