### PR TITLE
Use default `browser` instead of `chrome` for browser calls

### DIFF
--- a/help.html
+++ b/help.html
@@ -3,9 +3,9 @@
 		<title>Trello Scrum Help</title>
 	</head>
 	<body>
-		<h2>Trello Scrum Chrome Extension Help</h2>
+		<h2>Trello Scrum Browser Extension Help</h2>
 		<p>
-			Trello Scrum is a Chrome Extension that adds a little bit of functionality
+			Trello Scrum is a Browser Extension, currently for Firefox and Chrome, that adds a little bit of functionality
 			to Trello.com to make it perfect to use in SCRUM based projects. Trello Scrum
 			allows you to add story points to cards and accumulates the story points per list.
 		</p>

--- a/popup.js
+++ b/popup.js
@@ -1,5 +1,6 @@
+if (typeof(browser) === "undefined") browser = chrome;
 document.addEventListener('DOMContentLoaded', function restore_options() {
-    chrome.runtime.sendMessage({type: "getSettings"}, function (response) {
+    browser.runtime.sendMessage({type: "getSettings"}, function (response) {
         var key;
         for (key in response) {
             if (response.hasOwnProperty(key)) {
@@ -26,7 +27,7 @@ document.addEventListener('DOMContentLoaded', function restore_options() {
             if (e.target.type === "checkbox") {
                 value = e.target.checked;
             }
-            chrome.runtime.sendMessage({type: "settingUpdated", name: name, value: value });
+            browser.runtime.sendMessage({type: "settingUpdated", name: name, value: value });
             console.log("message sent from popup");
         });
     }

--- a/showPageAction.js
+++ b/showPageAction.js
@@ -1,3 +1,5 @@
+if (typeof(browser) === "undefined") browser = chrome;
+
 var DEFAULT_SETTINGS = {
     maxSize: 4,
     ghostCards: false,
@@ -11,13 +13,13 @@ var currentTab = undefined;
 
 
 //make sure the page action is shown when a trello url is opened
-chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+browser.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
     currentTab = tabId;
     trelloScrumUrlSpecificActions(tab);
 });
 
-chrome.tabs.onActivated.addListener(function (activeInfo) {
-    chrome.tabs.get(activeInfo.tabId, function (tab) {
+browser.tabs.onActivated.addListener(function (activeInfo) {
+    browser.tabs.get(activeInfo.tabId, function (tab) {
         currentTab = tab.id;
         trelloScrumUrlSpecificActions(tab);
     });
@@ -63,27 +65,27 @@ function applySettings(tab) {
         } else {
             settings = JSON.parse(localStorage[boardId]);
         }
-        chrome.tabs.sendMessage(tab.id, {type: "settings", content: settings, forBoard: boardId });
+        browser.tabs.sendMessage(tab.id, {type: "settings", content: settings, forBoard: boardId });
     }
 }
 
 function showSettingsIcon(tab) {
     //don't show the icon on settings pages or non-trello pages
     if (getTrelloLocation(tab.url) !== "other") {
-        chrome.pageAction.show(tab.id);
+        browser.pageAction.show(tab.id);
     }
 }
 
-chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     if (message.type === "getSettings") {
         sendResponse(settings);
     }
 });
 
-chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     if (message.type === "settingUpdated") {
         settings[message.name] = message.value;
         localStorage[boardId] = JSON.stringify(settings);
-        chrome.tabs.sendMessage(currentTab, {type: "settings", content: settings });
+        browser.tabs.sendMessage(currentTab, {type: "settings", content: settings });
     }
 });

--- a/trelloscrum.js
+++ b/trelloscrum.js
@@ -1,15 +1,17 @@
+if (typeof(browser) === "undefined") browser = chrome;
+
 (function () {
     "use strict";
     var mutationListeners = [];
     var MAX_SIZE = 4;
 
-    chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+    browser.runtime.onMessage.addListener(function (message, sender, sendResponse) {
         if (message.type === "settings") {
             applySettings(message.content);
         }
     });
 
-    chrome.runtime.sendMessage({type: "getSettings"}, function (response) {
+    browser.runtime.sendMessage({type: "getSettings"}, function (response) {
         applySettings(response);
     });
 


### PR DESCRIPTION
With this change the browser extension uses the standard `browser` instead of the chrome specific `chrome` object. With this change the extension is usable on both Firefox as Chrome.